### PR TITLE
Add docker compose self-hosting with MinIO

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "3.9"
+services:
+  postgres:
+    image: public.ecr.aws/z9j8u5b3/instant-public:postgresql-16-pg-hint-plan
+    environment:
+      POSTGRES_PASSWORD: pass
+      POSTGRES_USER: instant
+      POSTGRES_DB: instant
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "8890:5432"
+
+  minio:
+    image: minio/minio:RELEASE.2024-03-16T04-26-08Z
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio-data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    depends_on:
+      - postgres
+      - minio
+    environment:
+      PRODUCTION: "true"
+      DATABASE_URL: "postgresql://instant:pass@postgres:5432/instant"
+      S3_ENDPOINT: "http://minio:9000"
+      AWS_ACCESS_KEY_ID: minio
+      AWS_SECRET_ACCESS_KEY: minio123
+      AWS_REGION: us-east-1
+    ports:
+      - "8888:8888"
+    command: >-
+      sh -c 'java -Djava.awt.headless=true -server -jar target/instant-standalone.jar'
+
+  dash:
+    image: node:20
+    working_dir: /app
+    volumes:
+      - ./client:/app
+    command: sh -c 'corepack enable && pnpm install && pnpm --filter ./www run dev'
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server
+
+volumes:
+  postgres-data:
+  minio-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,21 +26,20 @@ services:
   server:
     build:
       context: ./server
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile-dev
     depends_on:
       - postgres
       - minio
     environment:
-      PRODUCTION: "true"
       DATABASE_URL: "postgresql://instant:pass@postgres:5432/instant"
       S3_ENDPOINT: "http://minio:9000"
       AWS_ACCESS_KEY_ID: minio
       AWS_SECRET_ACCESS_KEY: minio123
       AWS_REGION: us-east-1
+      NREPL_BIND_ADDRESS: "0.0.0.0"
     ports:
       - "8888:8888"
-    command: >-
-      sh -c 'java -Djava.awt.headless=true -server -jar target/instant-standalone.jar'
+      - "6005:6005"
 
   dash:
     image: node:20

--- a/server/README.md
+++ b/server/README.md
@@ -85,6 +85,29 @@ make test
 
 If you want to make any changes to your configuration, update the `resources/config/override.edn` file that was created when you ran `make docker-compose` or `make bootstrap-oss`. `src/instant/config_edn.clj` has a spec that describes the data for the file, or you can look at `resources/config/dev.edn` for an example.
 
+## Self-hosting on a custom domain
+
+The repo includes a `docker-compose.yml` that runs the Instant server, dashboard,
+Postgres and a MinIO instance. To run everything:
+
+```sh
+docker compose up
+```
+
+Instant will listen on `http://localhost:8888` by default. Set `PRODUCTION=true`
+and override `SERVER_ORIGIN` if you want to expose a custom domain. The server
+uses this value when it builds OAuth callback URLs and upload links:
+
+```sh
+PRODUCTION=true SERVER_ORIGIN=https://example.com docker compose up
+```
+
+The server also reads `S3_ENDPOINT` for a custom S3-compatible endpoint. The
+compose file sets this to the included MinIO service.
+
+Update your DNS or reverse proxy to forward traffic to port `8888` on the host.
+Login emails are printed to the server logs so you can copy the magic code.
+
 # Questions?
 
 If you have any questions, feel free to drop us a line on our [Discord](https://discord.com/invite/VU53p7uQcE).

--- a/server/README.md
+++ b/server/README.md
@@ -95,12 +95,15 @@ root run:
 docker compose up
 ```
 
-Instant will listen on `http://localhost:8888` by default. Set `PRODUCTION=true`
-and override `SERVER_ORIGIN` if you want to expose a custom domain. The server
-uses this value when it builds OAuth callback URLs and upload links:
+The server image runs `make dev-oss` so it bootstraps the configuration and
+migrates the database automatically on first start.
+
+Instant will listen on `http://localhost:8888` by default. Override
+`SERVER_ORIGIN` if you want to expose a custom domain. The server uses this
+value when it builds OAuth callback URLs and upload links:
 
 ```sh
-PRODUCTION=true SERVER_ORIGIN=https://example.com docker compose up
+SERVER_ORIGIN=https://example.com docker compose up
 ```
 
 The server also reads `S3_ENDPOINT` for a custom S3-compatible endpoint. The

--- a/server/README.md
+++ b/server/README.md
@@ -87,8 +87,9 @@ If you want to make any changes to your configuration, update the `resources/con
 
 ## Self-hosting on a custom domain
 
-The repo includes a `docker-compose.yml` that runs the Instant server, dashboard,
-Postgres and a MinIO instance. To run everything:
+The repo includes a `docker-compose.yml` at the repository root that runs the
+Instant server, dashboard, Postgres and a MinIO instance. From the repository
+root run:
 
 ```sh
 docker compose up

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -199,13 +199,18 @@
   (or (System/getenv "HONEYCOMB_ENDPOINT")
       "https://api.honeycomb.io:443"))
 
+(defn get-s3-endpoint []
+  (System/getenv "S3_ENDPOINT"))
+
 (defn get-google-oauth-client []
   (-> @config-map :google-oauth-client))
 
-(def server-origin (case (get-env)
-                     :prod "https://api.instantdb.com"
-                     :staging "https://api-staging.instantdb.com"
-                     "http://localhost:8888"))
+(def server-origin
+  (or (System/getenv "SERVER_ORIGIN")
+      (case (get-env)
+        :prod "https://api.instantdb.com"
+        :staging "https://api-staging.instantdb.com"
+        "http://localhost:8888")))
 
 (def s3-bucket-name
   (case (get-env)

--- a/server/src/instant/storage/s3.clj
+++ b/server/src/instant/storage/s3.clj
@@ -5,26 +5,43 @@
             [instant.util.date :as date-util])
   (:import
    [software.amazon.awssdk.auth.credentials DefaultCredentialsProvider]
-   [software.amazon.awssdk.services.s3 S3AsyncClient S3Client]
+   [software.amazon.awssdk.services.s3 S3AsyncClient S3Client S3Configuration]
    [java.time Duration Instant]
-   [java.time.temporal ChronoUnit]))
+   [java.time.temporal ChronoUnit]
+   [java.net URI]))
 
 (set! *warn-on-reflection* true)
 
 ;; Configuration
 ;; ----------------------
 
-(def ^:private s3-client* (delay (.build (S3Client/builder))))
+(def ^:private s3-client*
+  (delay
+    (let [builder (S3Client/builder)]
+      (when-let [endpoint (config/get-s3-endpoint)]
+        (.endpointOverride builder (URI/create endpoint))
+        (.serviceConfiguration builder
+                               (-> (S3Configuration/builder)
+                                   (.pathStyleAccessEnabled true)
+                                   (.build))))
+      (.build builder))))
 
 (defn s3-client
   "Standard blocking S3 client. We use this for most operations."
   ^S3Client []
   @s3-client*)
 
-(def ^:private s3-async-client* (delay
-                                  (-> (S3AsyncClient/crtBuilder)
-                                      (.targetThroughputInGbps 20.0)
-                                      (.build))))
+(def ^:private s3-async-client*
+  (delay
+    (let [builder (-> (S3AsyncClient/crtBuilder)
+                      (.targetThroughputInGbps 20.0))]
+      (when-let [endpoint (config/get-s3-endpoint)]
+        (.endpointOverride builder (URI/create endpoint))
+        (.serviceConfiguration builder
+                               (-> (S3Configuration/builder)
+                                   (.pathStyleAccessEnabled true)
+                                   (.build))))
+      (.build builder))))
 
 (defn s3-async-client
   "Async S3 Client. Useful when you want to asynchronously upload streams to S3"


### PR DESCRIPTION
## Summary
- add a docker-compose.yml for self-hosting with Postgres, MinIO, server and dashboard
- allow overriding the S3 endpoint via `S3_ENDPOINT`
- update S3 client constructors to honour the new endpoint and use path style
- document self-hosting and custom domain configuration
- allow overriding `server-origin` with `SERVER_ORIGIN`

## Testing
- `make test` *(fails: `/bin/sh: 1: clojure: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68447b6759d083259124663a6b11d5b5