### PR TITLE
Allow dashboard origin override

### DIFF
--- a/self-host/README.md
+++ b/self-host/README.md
@@ -55,6 +55,19 @@ export SERVER_ORIGIN="https://api.example.com"
 
 Restart the jar to pick up the new value.
 
+## Overriding the dashboard origin
+
+The frontend dashboard uses `dashboard-origin` to generate OAuth redirect URLs
+and to validate CORS requests. By default this value depends on the environment
+and falls back to `http://localhost:3000` when running locally. You can override
+it at runtime:
+
+```bash
+export DASHBOARD_ORIGIN="https://dashboard.example.com"
+```
+
+Restart the jar to pick up the new value.
+
 ## Using Minio instead of S3
 
 Set `S3_ENDPOINT` to point the S3 clients at your local Minio instance:

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -157,12 +157,16 @@
                                                       @process-id)))))
 
 (defn dashboard-origin
+  "Return the base URL for the Instant dashboard. The value normally depends on
+  the current environment but can be overridden with the `DASHBOARD_ORIGIN`
+  environment variable."
   ([] (dashboard-origin {:env (get-env)}))
   ([{:keys [env]}]
-   (case env
-     :prod "https://www.instantdb.com"
-     :staging "https://staging.instantdb.com"
-     "http://localhost:3000")))
+   (or (System/getenv "DASHBOARD_ORIGIN")
+       (case env
+         :prod "https://www.instantdb.com"
+         :staging "https://staging.instantdb.com"
+         "http://localhost:3000"))))
 
 ;; ---
 ;; Stripe


### PR DESCRIPTION
## Summary
- let `dashboard-origin` be overridden with `DASHBOARD_ORIGIN`
- document dashboard override in self-host docs

## Testing
- `make lint` *(fails: `clojure: not found`)*
- `make test` *(fails: `clojure: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd039de483259f5dbef1bd0ababd