### PR TITLE
Make OAuth scope configurable

### DIFF
--- a/self-host/README.md
+++ b/self-host/README.md
@@ -3,6 +3,7 @@
 ## Backend
 
 - Override server origin for OAuth with env var: `SERVER_ORIGIN`
+- Override OAuth scope with env var: `OAUTH_DEFAULT_SCOPE`
 - Override S3: TBD
 
 ## Frontend

--- a/self-host/README.md
+++ b/self-host/README.md
@@ -34,6 +34,52 @@ If you are running remotely, you will need to construct the URL after you Sign U
 http://my-local-lab-host:8888/dash?ticket=f232863d-bfb0-4af5-a1c1-9d9f8fc8a5c5
 ```
 
+Then it will also print the token you can use for Keycloak setup if you like...
+
+## Keycloak Setup
+
+The token generated above can be used as a `Bearer` token for admin REST calls. Here is how you set up auth with your own Keycloak:
+
+```
+curl -X POST "https://my-instant-db.domain.com/dash/apps/63bef763-f7d2-4436-9ac6-f816c9824e96/oauth_service_providers" \
+  -H "Authorization: Bearer <ADMNIN TOKEN GOES HERE>" \
+  -H "Content-Type: application/json" \
+  -d '{ "provider_name": "keycloak" }'
+```
+
+Example output:
+
+```
+{"provider":{"id":"3e575dfa-15b3-40fd-bd5e-1cc612969dfb","provider_name":"keycloak","created_at":"2025-06-12T01:13:00Z"}}
+```
+
+Next, take the keycloak client details you made in keycloak and set them on that provider you added:
+
+```
+curl -X POST "https://my-instant-db.domain.com/dash/apps/63bef763-f7d2-4436-9ac6-f816c9824e96/oauth_clients" \
+  -H "Authorization: Bearer <ADMNIN TOKEN GOES HERE>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "provider_id": "3e575dfa-15b3-40fd-bd5e-1cc612969dfb",
+        "client_name": "my-keycloak",
+        "client_id": "instant",
+        "client_secret": "REDACTED",
+        "discovery_endpoint": "https://keycloak.domain.com/realms/MY_REALM/.well-known/openid-configuration"
+      }'
+```
+
+Example output:
+
+```
+{"client":{"id":"095f7576-cef1-423f-8111-49f1e44a3238","provider_id":"3e575dfa-15b3-40fd-bd5e-1cc612969dfb","client_name":"my-keycloak","client_id":"instant","created_at":"2025-06-12T10:03:55Z","meta":null,"discovery_endpoint":"https://keycloak.domain.com/realms/MY_REALM/.well-known/openid-configuration"}}
+```
+
+Then in the Dashboard, you need to add your web app domain to the list of Website Origins under Auth.
+
+And if you are using Keycloak, you need to set this env var: `OAUTH_DEFAULT_SCOPE=email openid`
+
+Instant needs an ID token and Keycloak needs to be asked for `openid` to give it.
+
 # Other Points
 
 ## Building the jar

--- a/self-host/docker-compose-coolify.yml
+++ b/self-host/docker-compose-coolify.yml
@@ -38,7 +38,8 @@ services:
       - "random_page_cost=1.1"
 
   backend:
-    image: ghcr.io/bioshazard/instant/server:main
+    # image: ghcr.io/bioshazard/instant/server:main
+    image: instant-api:test
     # ports:
     #   - '8888:8888'
     #   - '6005:6005'
@@ -50,14 +51,17 @@ services:
       - SERVICE_FQDN_INSTANTAPI_8888
       - DATABASE_URL=postgresql://${SERVICE_USER_POSTGRES}:${SERVICE_PASSWORD_POSTGRES}@postgres:5432/${POSTGRES_DB:-instant}
       - SERVER_ORIGIN=$SERVICE_FQDN_INSTANTAPI_8888
+      # - SERVER_ORIGIN=https://instant-api.domain.com # you might need to hard code this... mine stuck to the original auto-FQDN
       - NREPL_BIND_ADDRESS=0.0.0.0
 
       # Change to your Minio host and auth (bucket is hard-coded as "instantdb-test-bucket" for now, see server/src/)
       # Or delete S3_ENDPOINT to use AWS S3
-      # - S3_ENDPOINT=CHANGEME
       # - S3_BUCKET=instantdb-test-bucket # TODO, add env var
+      - S3_ENDPOINT=CHANGEME
       - AWS_ACCESS_KEY=REPLACEME
       - AWS_SECRET_ACCESS_KEY=REPLACEME
+      # Keycloak needs `openid` too
+      - OAUTH_DEFAULT_SCOPE=email openid
       
     stop_grace_period: 2m
     restart: on-failure

--- a/server/src/instant/auth/oauth.clj
+++ b/server/src/instant/auth/oauth.clj
@@ -5,6 +5,7 @@
    [clojure.core.cache.wrapped :as cache]
    [clojure.string :as string]
    [instant.auth.jwt :as jwt]
+   [instant.config :as config]
    [instant.util.crypt :as crypt-util]
    [instant.util.exception :as ex]
    [instant.util.lang :as lang]
@@ -18,6 +19,7 @@
    (java.util Base64)))
 
 (def allowed-extra-params [:hd])
+
 
 (defprotocol OAuthClient
   (create-authorization-url [this state redirect-url extra-params])
@@ -37,7 +39,7 @@
                                meta]
   OAuthClient
   (create-authorization-url [_ state redirect-url extra-params]
-    (let [base-params {:scope "email"
+    (let [base-params {:scope config/oauth-default-scope
                        :response_type "code"
                        :response_mode "form_post"
                        :state state

--- a/server/src/instant/config.clj
+++ b/server/src/instant/config.clj
@@ -213,6 +213,9 @@
         :staging "https://api-staging.instantdb.com"
         "http://localhost:8888")))
 
+(def oauth-default-scope
+  (or (System/getenv "OAUTH_DEFAULT_SCOPE") "email"))
+
 (def s3-bucket-name
   (case (get-env)
     :prod "instant-storage"


### PR DESCRIPTION
## Summary
- allow overriding OAuth auth URL scope via `OAUTH_DEFAULT_SCOPE`
- document new env variable in self-host README

## Testing
- `make test` *(fails: `clojure: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ad1bd08748325ac556a2153ad8e07